### PR TITLE
70 improvements

### DIFF
--- a/dkan_dataset_metadata_source.features.field_base.inc
+++ b/dkan_dataset_metadata_source.features.field_base.inc
@@ -13,7 +13,7 @@ function dkan_dataset_metadata_source_field_default_field_bases() {
   // Exported field_base: 'field_dataset_metadata_ref'
   $field_bases['field_dataset_metadata_ref'] = array(
     'active' => 1,
-    'cardinality' => 1,
+    'cardinality' => -1,
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_dataset_metadata_ref',

--- a/dkan_dataset_metadata_source.features.field_instance.inc
+++ b/dkan_dataset_metadata_source.features.field_instance.inc
@@ -84,7 +84,7 @@ function dkan_dataset_metadata_source_field_default_field_instances() {
       'active' => 1,
       'module' => 'options',
       'settings' => array(
-        'apply_chosen' => 0,
+        'apply_chosen' => 1,
       ),
       'type' => 'options_select',
       'weight' => 4,

--- a/dkan_dataset_metadata_source.features.field_instance.inc
+++ b/dkan_dataset_metadata_source.features.field_instance.inc
@@ -179,7 +179,7 @@ function dkan_dataset_metadata_source_field_default_field_instances() {
     'entity_type' => 'node',
     'field_name' => 'field_metadata_schema',
     'label' => 'Schema',
-    'required' => 0,
+    'required' => 1,
     'settings' => array(
       'user_register_form' => FALSE,
     ),

--- a/dkan_dataset_metadata_source.theme.inc
+++ b/dkan_dataset_metadata_source.theme.inc
@@ -68,7 +68,7 @@ function theme_dkan_dataset_metadata_source_view($vars) {
             ),
           )
         );
-        $title = l($metadata_source_wrapper->title->value(), $view_url, array(
+        $title = l($title, $view_url, array(
           'html' => TRUE,
           'attributes' => array(
             'class' => array('heading'),


### PR DESCRIPTION
This responds to https://github.com/NuCivic/data-northdakota/issues/70
## Acceptance test

When adding a new metadata source, the following thins should happen:
- [x] the field schema should be required
- [x] we should be able to add more than one dataset to each source
- [x] we should be able to use chosen to select the datasets

When viewing a dataset which has a reference to a metadata source, then
- [x] if the metadata source has a schema, then the title should be the term name, otherwise the title should be the node title.
