### PR TITLE
Check the dataset update access for "Add Metadata"

### DIFF
--- a/dkan_dataset_metadata_source.module
+++ b/dkan_dataset_metadata_source.module
@@ -31,7 +31,7 @@ function dkan_dataset_metadata_source_add_metadata_access($node) {
   if ($node->type != 'dataset') {
     return FALSE;
   }
-  elseif (node_hook($node->type, 'form') && node_access('create', $node->type)) {
+  elseif (node_hook($node->type, 'form') && node_access('update', $node)) {
     return TRUE;
   }
   else {


### PR DESCRIPTION
Ref. NuCivic/usda-nal#714
Dkan issue: https://github.com/NuCivic/dkan/issues/902

Currently any user with the 'create dataset content' permission have access to
the "Add Metadata" tab even if he did not create the said dataset or his access
level should not allow him to update it. This change will make the "Add
Metadata" visible to only users with the 'edit own dataset content' or the 'edit
any dataset content' permissions.
