### PR TITLE
Added description of the module in .info file.

### DIFF
--- a/dkan_dataset_metadata_source.info
+++ b/dkan_dataset_metadata_source.info
@@ -3,6 +3,7 @@ core = 7.x
 package = DKAN
 version = 7.x-2.0
 project = dkan_dataset_metadata_source
+description = Add metadata source content type and metadata type vocabulary.
 dependencies[] = ctools
 dependencies[] = dkan_dataset_content_types
 dependencies[] = entityreference


### PR DESCRIPTION
## Desription

When module dkan_dataset_metadata_source is not available, it doesn't shows why it is unavailable. Also, in the module list it is not a description of the module.
http://a.disquscdn.com/uploads/mediaembed/images/2939/9984/original.jpg
## Aceptance Criteria
- [ ] When you visit the module list page and search for dkan_dataset_metadata_source, you can see the module description.
- [ ] If the module is listed as "unavailable", you can see why it is unavailable, you must see something like: http://prntscr.com/9ffbzj
